### PR TITLE
Add Travis CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,26 @@
+# Copyright 2018 DigitalOcean
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+language: minimal
+sudo: required
+services:
+  - docker
+
+before_install:
+  - docker pull koalaman/shellcheck:stable
+  - docker pull particlekit/ansible-lint:latest
+
+script:
+  - docker build -t terraform-ansible:latest .
+  - make check

--- a/Makefile
+++ b/Makefile
@@ -16,19 +16,30 @@ check: shellcheck ansible-lint terraform-validate
 .PHONY: check
 
 shellcheck:
-	find . -name '*.sh' -exec shellcheck {} \;
+	find . -name '*.sh' \
+		-exec docker run -it --rm \
+		-v $(PWD):$(PWD) \
+		-w $(PWD) \
+		koalaman/shellcheck:stable {} \
+		\;
 .PHONY: shellcheck
 
 ansible-lint:
 	docker run -it --rm \
 		-v $(PWD):$(PWD) \
 		-w $(PWD) \
-		particlekit/ansible-lint \
+		particlekit/ansible-lint:latest \
 		ansible-lint ./ansible/*.yml
 .PHONY: ansible-lint
 
 terraform-validate:
 	docker build -t terraform-ansible:latest .
+	docker run -it --rm \
+		-v $(PWD):$(PWD) \
+		-w $(PWD) \
+		--entrypoint /bin/terraform \
+		terraform-ansible:latest \
+		init
 	docker run -it --rm \
 		-v $(PWD):$(PWD) \
 		-w $(PWD) \


### PR DESCRIPTION
Add a Travis CI configuration to pull dependencies, build our `terraform-ansible` docker image, and run `make check`. This should ensure at least basic sanity for both master and incoming changes.