### PR TITLE
Use copy instead of blockinfile to create ssh keys

### DIFF
--- a/ansible/roles/head-node/tasks/main.yml
+++ b/ansible/roles/head-node/tasks/main.yml
@@ -89,13 +89,11 @@
 - name: place teuthology user ssh key
   become: yes
   become_user: teuthology
-  blockinfile:
-    path: /home/teuthology/.ssh/id_rsa
-    marker: ""
+  copy:
+    dest: /home/teuthology/.ssh/id_rsa
     mode: 0600
-    block: |
+    content: |
       {{ ssh_priv_key }}
-    create: yes
 
 - name: create .ssh directory for teuthworker
   become: yes
@@ -108,13 +106,11 @@
 - name: place teuthworker user ssh key
   become: yes
   become_user: teuthworker
-  blockinfile:
-    path: /home/teuthworker/.ssh/id_rsa
-    marker: ""
+  copy:
+    dest: /home/teuthworker/.ssh/id_rsa
     mode: 0600
-    block: |
+    content: |
       {{ ssh_priv_key }}
-    create: yes
 
 - name: create teuthology src directory
   become: yes

--- a/ansible/roles/test-node/tasks/main.yml
+++ b/ansible/roles/test-node/tasks/main.yml
@@ -68,13 +68,11 @@
     create: yes
 
 - name: place root ssh key
-  blockinfile:
-    path: /root/.ssh/id_rsa
-    marker: ""
+  copy:
+    dest: /root/.ssh/id_rsa
     mode: 0600
-    block: |
+    content: |
       {{ ssh_priv_key }}
-    create: yes
 
 - name: create scratch_devs file
   shell: "ls -1 /dev/sd* > /scratch_devs"


### PR DESCRIPTION
In some recent Ansible release, blockinfile started inserting newlines before blocks, even when creating a new file. This breaks SSH key creation, since ssh requires an SSH private key to have no leading or trailing newlines.

Use the copy module instead.